### PR TITLE
Use theStrongSelf in case self has been deallocated before the animation completion block gets called

### DIFF
--- a/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
+++ b/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
@@ -264,10 +264,11 @@ static NSString * const kLXReorderableCollectionViewFlowLayoutScrollingDirection
                      [theStrongSelf.currentView removeFromSuperview];
                      [theStrongSelf invalidateLayout];
                      
-                     if ([self.collectionView.delegate conformsToProtocol:@protocol(LXReorderableCollectionViewDelegateFlowLayout)]) {
-                         id<LXReorderableCollectionViewDelegateFlowLayout> theDelegate = (id<LXReorderableCollectionViewDelegateFlowLayout>)self.collectionView.delegate;
+                     // Use theStrongSelf in case self has been deallocated before the completion block gets called.
+                     if ([theStrongSelf.collectionView.delegate conformsToProtocol:@protocol(LXReorderableCollectionViewDelegateFlowLayout)]) {
+                         id<LXReorderableCollectionViewDelegateFlowLayout> theDelegate = (id<LXReorderableCollectionViewDelegateFlowLayout>)theStrongSelf.collectionView.delegate;
                          if ([theDelegate respondsToSelector:@selector(collectionView:layout:didEndReorderingAtIndexPath:)]) {
-                             [theDelegate collectionView:self.collectionView layout:self didEndReorderingAtIndexPath:theIndexPathOfSelectedItem];
+                             [theDelegate collectionView:theStrongSelf.collectionView layout:theStrongSelf didEndReorderingAtIndexPath:theIndexPathOfSelectedItem];
                          }
                      }
                  }];


### PR DESCRIPTION
Use theStrongSelf in case self has been deallocated before the completion block gets called (usually with multiple touches). Cause occasional crashes when removing the collectionView while something is being moved.

Wasn't sure if a weak reference is preferred, but using the strong reference definitely works.
