### PR TITLE
Fix ordering of adding long press gesture recognizer

### DIFF
--- a/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
+++ b/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
@@ -70,7 +70,6 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
     _longPressGestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self
                                                                                 action:@selector(handleLongPressGesture:)];
     _longPressGestureRecognizer.delegate = self;
-    [self.collectionView addGestureRecognizer:_longPressGestureRecognizer];
     
     // Links the default long press gesture recognizer to the custom long press gesture recognizer we are creating now
     // by enforcing failure dependency so that they doesn't clash.
@@ -79,6 +78,8 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
             [gestureRecognizer requireGestureRecognizerToFail:_longPressGestureRecognizer];
         }
     }
+    
+    [self.collectionView addGestureRecognizer:_longPressGestureRecognizer];
     
     _panGestureRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self
                                                                     action:@selector(handlePanGesture:)];


### PR DESCRIPTION
I'm seeing repeatable crashes upon `dealloc` in the `UILongPressGestureRecognizer` associated with LXReorderableCollectionViewFlowLayout.

I believe this stems from the order in which LXReorderableCollectionViewFlowLayout sets up its gesture recognizers on the collection view in `setupCollectionView`. 

Specifically, my collection view does not have a default long press gesture recognizer, so when `setupCollectionView` calls `-requireGestureRecognizerToFail` to attach it to the default long press recognizer, it actually ends up requiring itself to fail and thusly (I'd guess) prevents itself from being deallocated. 

The fix is simple: don't add the new long press gesture recognizer to the collection view until after any other `-requireGestureRecognizerToFail` dependencies are set up.
