### PR TITLE
Gracefully cancel cell reordering when application will resign active notification sent

### DIFF
--- a/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
+++ b/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
@@ -85,6 +85,9 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
                                                                     action:@selector(handlePanGesture:)];
     _panGestureRecognizer.delegate = self;
     [self.collectionView addGestureRecognizer:_panGestureRecognizer];
+
+    // Useful in multiple scenarios: one common scenario being when the Notification Center drawer is pulled down
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleApplicationWillResignActive:) name: UIApplicationWillResignActiveNotification object:nil];
 }
 
 - (id)init {
@@ -303,6 +306,7 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
             
             [self invalidateLayout];
         } break;
+        case UIGestureRecognizerStateCancelled:
         case UIGestureRecognizerStateEnded: {
             NSIndexPath *currentIndexPath = self.selectedItemIndexPath;
             
@@ -381,6 +385,7 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
                 } break;
             }
         } break;
+        case UIGestureRecognizerStateCancelled:
         case UIGestureRecognizerStateEnded: {
             [self invalidatesScrollTimer];
         } break;
@@ -455,6 +460,13 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
             [self invalidatesScrollTimer];
         }
     }
+}
+
+#pragma mark - Notifications
+
+- (void)handleApplicationWillResignActive:(NSNotification *)notification {
+    self.panGestureRecognizer.enabled = NO;
+    self.panGestureRecognizer.enabled = YES;
 }
 
 #pragma mark - Depreciated methods


### PR DESCRIPTION
The example with the card images doesn't reflect this bug (because of the ample spacing between the cells and the status bar), but if your cells are flush against to status bar (in iPhone, at least), when the user long presses on a cell at the top, the Notification Center drawer is pulled down and the cell gets stuck in the long press state.

Here's what I mean by it getting stuck in the long press state:
http://cl.ly/image/0H0y2n1M2o0Q

Pay attention to the "Groceries" cell.  My finger is no longer on the screen, but the rasterized cell is stuck in place.  This totally breaks the scroll view.
