### PR TITLE
Fix "cell is slipping away under finger"-bug

### DIFF
--- a/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
+++ b/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
@@ -213,7 +213,9 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
     CGSize frameSize = self.collectionView.bounds.size;
     CGSize contentSize = self.collectionView.contentSize;
     CGPoint contentOffset = self.collectionView.contentOffset;
-    CGFloat distance = self.scrollingSpeed / LX_FRAMES_PER_SECOND;
+    // Important to have an integer `distance` as the `contentOffset` property automatically gets rounded
+    // and it would diverge from the view's center resulting in a "cell is slipping away under finger"-bug.
+    CGFloat distance = rint(self.scrollingSpeed / LX_FRAMES_PER_SECOND);
     CGPoint translation = CGPointZero;
     
     switch(direction) {


### PR DESCRIPTION
By rounding `distance` to an integer.

Setting a non-integral value to `self.collectionView.contentOffset` will get rounded automatically anyway but `self.currentViewCenter` and `self.currentView.center` won't and that's where the values slowly diverge if the speed is not dividable without rest by 60 (the default fps). The default speed is 300 but bumping it up to e.g. 500 for faster scrolling caused the bug to happen.
