### PR TITLE
Nil the gesture recognizer delegate's to fix crash

### DIFF
--- a/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
+++ b/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
@@ -124,6 +124,8 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
 }
 
 - (void)dealloc {
+    self.panGestureRecognizer.delegate = nil;
+    self.longPressGestureRecognizer.delegate = nil;
     [self invalidatesScrollTimer];
     [self removeObserver:self forKeyPath:kLXCollectionViewKeyPath];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationWillResignActiveNotification object:nil];


### PR DESCRIPTION
 Getting "message sent to deallocated instance" on the UIGestureRecognizers when the view controller is popped from the navigation controller.

Nil'ing the delegate fixes the crash.

For me this fixes #51 
