### PR TITLE
Take collectionView contentInsets into account when scrolling

### DIFF
--- a/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
+++ b/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
@@ -213,6 +213,7 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
     CGSize frameSize = self.collectionView.bounds.size;
     CGSize contentSize = self.collectionView.contentSize;
     CGPoint contentOffset = self.collectionView.contentOffset;
+    UIEdgeInsets contentInset = self.collectionView.contentInset;
     // Important to have an integer `distance` as the `contentOffset` property automatically gets rounded
     // and it would diverge from the view's center resulting in a "cell is slipping away under finger"-bug.
     CGFloat distance = rint(self.scrollingSpeed / LX_FRAMES_PER_SECOND);
@@ -221,16 +222,16 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
     switch(direction) {
         case LXScrollingDirectionUp: {
             distance = -distance;
-            CGFloat minY = 0.0f;
+            CGFloat minY = 0.0f - contentInset.top;
             
             if ((contentOffset.y + distance) <= minY) {
-                distance = -contentOffset.y;
+                distance = -contentOffset.y - contentInset.top;
             }
             
             translation = CGPointMake(0.0f, distance);
         } break;
         case LXScrollingDirectionDown: {
-            CGFloat maxY = MAX(contentSize.height, frameSize.height) - frameSize.height;
+            CGFloat maxY = MAX(contentSize.height, frameSize.height) - frameSize.height + contentInset.bottom;
             
             if ((contentOffset.y + distance) >= maxY) {
                 distance = maxY - contentOffset.y;
@@ -240,16 +241,16 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
         } break;
         case LXScrollingDirectionLeft: {
             distance = -distance;
-            CGFloat minX = 0.0f;
+            CGFloat minX = 0.0f - contentInset.left;
             
             if ((contentOffset.x + distance) <= minX) {
-                distance = -contentOffset.x;
+                distance = -contentOffset.x - contentInset.left;
             }
             
             translation = CGPointMake(distance, 0.0f);
         } break;
         case LXScrollingDirectionRight: {
-            CGFloat maxX = MAX(contentSize.width, frameSize.width) - frameSize.width;
+            CGFloat maxX = MAX(contentSize.width, frameSize.width) - frameSize.width + contentInset.right;
             
             if ((contentOffset.x + distance) >= maxX) {
                 distance = maxX - contentOffset.x;


### PR DESCRIPTION
This patch makes LXReorderableCollectionViewFlowLayout handle scrolling while dragging better if collectionView has contentInsets
