### PR TITLE
Add delegate methods for controlling visual changes and movement of the ...

### DIFF
--- a/LXRCVFL Example using Storyboard/LXRCVFL Example using Storyboard/LXCollectionViewController.m
+++ b/LXRCVFL Example using Storyboard/LXRCVFL Example using Storyboard/LXCollectionViewController.m
@@ -16,11 +16,23 @@
 
 #define LX_LIMITED_MOVEMENT 0
 
+// LX_CUSTOM_ADJUSTMENT_FOR_DRAGDROP_VISUAL:
+// 0 = Use default visual adjustments
+// 1 = Use delegate methods to control visual adjustments
+
+#define LX_CUSTOM_ADJUSTMENT_FOR_DRAGDROP_VISUAL 0
+
+// LX_CUSTOM_TRANSLATION_ADJUSTMENT:
+// 0 = Unrestricted movement
+// 1 = Restrict movement freedom via delegate
+
+#define LX_CUSTOM_TRANSLATION_ADJUSTMENT 0
+
 @implementation LXCollectionViewController
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    
+
     self.deck = [self constructsDeck];
 }
 
@@ -141,5 +153,36 @@
 - (void)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout didEndDraggingItemAtIndexPath:(NSIndexPath *)indexPath {
      NSLog(@"did end drag");
 }
+
+#if LX_CUSTOM_ADJUSTMENT_FOR_DRAGDROP_VISUAL == 1
+
+- (void)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout adjustCurrentViewForDragAnimated:(UIView *)currentView {
+    currentView.alpha = 0.8;
+    currentView.transform = CGAffineTransformRotate(CGAffineTransformMakeScale(1.2, 1.2), M_PI_4);
+}
+
+- (void)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout adjustCurrentViewForDropAnimated:(UIView *)currentView {
+    currentView.alpha = 1.0;
+}
+
+#endif
+
+#if LX_CUSTOM_TRANSLATION_ADJUSTMENT == 1
+
+- (CGPoint)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout adjustTranslation:(CGPoint)translation forDragOfCurrentView:(UIView *)currentView {
+    CGPoint adjustedTranslation = translation;
+    LXReorderableCollectionViewFlowLayout *reordableFlowLayout = (id)collectionViewLayout;
+    switch (reordableFlowLayout.scrollDirection) {
+        case UICollectionViewScrollDirectionVertical:
+            adjustedTranslation.x = 0;
+            break;
+        case UICollectionViewScrollDirectionHorizontal:
+            adjustedTranslation.y = 0;
+            break;
+    }
+    return adjustedTranslation;
+}
+
+#endif
 
 @end

--- a/LXRCVFL Example using Storyboard/LXRCVFL Example using Storyboard/LXCollectionViewController.m
+++ b/LXRCVFL Example using Storyboard/LXRCVFL Example using Storyboard/LXCollectionViewController.m
@@ -16,11 +16,23 @@
 
 #define LX_LIMITED_MOVEMENT 0
 
+// LX_CUSTOM_ADJUSTMENT_FOR_DRAGDROP_VISUAL:
+// 0 = Use default visual adjustments
+// 1 = Use delegate methods to control visual adjustments
+
+#define LX_CUSTOM_ADJUSTMENT_FOR_DRAGDROP_VISUAL 0
+
+// LX_CUSTOM_TRANSLATION_ADJUSTMENT:
+// 0 = Unrestricted movement
+// 1 = Restrict movement freedom via delegate
+
+#define LX_CUSTOM_TRANSLATION_ADJUSTMENT 0
+
 @implementation LXCollectionViewController
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    
+
     self.deck = [self constructsDeck];
 }
 
@@ -137,5 +149,36 @@
 - (void)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout didEndDraggingItemAtIndexPath:(NSIndexPath *)indexPath {
      NSLog(@"did end drag");
 }
+
+#if LX_CUSTOM_ADJUSTMENT_FOR_DRAGDROP_VISUAL == 1
+
+- (void)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout adjustCurrentViewForDragAnimated:(UIView *)currentView {
+    currentView.alpha = 0.8;
+    currentView.transform = CGAffineTransformRotate(CGAffineTransformMakeScale(1.2, 1.2), M_PI_4);
+}
+
+- (void)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout adjustCurrentViewForDropAnimated:(UIView *)currentView {
+    currentView.alpha = 1.0;
+}
+
+#endif
+
+#if LX_CUSTOM_TRANSLATION_ADJUSTMENT == 1
+
+- (CGPoint)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout adjustTranslation:(CGPoint)translation forDragOfCurrentView:(UIView *)currentView {
+    CGPoint adjustedTranslation = translation;
+    LXReorderableCollectionViewFlowLayout *reordableFlowLayout = (id)collectionViewLayout;
+    switch (reordableFlowLayout.scrollDirection) {
+        case UICollectionViewScrollDirectionVertical:
+            adjustedTranslation.x = 0;
+            break;
+        case UICollectionViewScrollDirectionHorizontal:
+            adjustedTranslation.y = 0;
+            break;
+    }
+    return adjustedTranslation;
+}
+
+#endif
 
 @end

--- a/LXReorderableCollectionViewFlowLayout.podspec
+++ b/LXReorderableCollectionViewFlowLayout.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
     :git => 'https://github.com/lxcid/LXReorderableCollectionViewFlowLayout.git',
     :tag => '0.1.1'
   }
-  s.platform = :ios, '4.3'
+  s.platform = :ios, '6.0'
   s.source_files = 'LXReorderableCollectionViewFlowLayout/'
   s.public_header_files = 'LXReorderableCollectionViewFlowLayout/'
   s.frameworks = 'UIKit', 'CoreGraphics'

--- a/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.h
+++ b/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.h
@@ -38,4 +38,8 @@
 - (void)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout willEndDraggingItemAtIndexPath:(NSIndexPath *)indexPath;
 - (void)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout didEndDraggingItemAtIndexPath:(NSIndexPath *)indexPath;
 
+- (void)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout adjustCurrentViewForDragAnimated:(UIView*)currentView;
+- (CGPoint)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout adjustTranslation:(CGPoint)translation forDragOfCurrentView:(UIView*)currentView;
+- (void)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout adjustCurrentViewForDropAnimated:(UIView*)currentView;
+
 @end

--- a/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
+++ b/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
@@ -268,6 +268,7 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
     self.currentViewCenter = LXS_CGPointAdd(self.currentViewCenter, translation);
     self.currentView.center = LXS_CGPointAdd(self.currentViewCenter, self.panTranslationInCollectionView);
     self.collectionView.contentOffset = LXS_CGPointAdd(contentOffset, translation);
+    [self invalidateLayoutIfNecessary];
 }
 
 

--- a/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
+++ b/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
@@ -84,6 +84,9 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
 }
 
 - (void)setupCollectionView {
+    if (_longPressGestureRecognizer) {
+        [self.collectionView removeGestureRecognizer:_longPressGestureRecognizer];
+    }
     _longPressGestureRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self
                                                                                 action:@selector(handleLongPressGesture:)];
     _longPressGestureRecognizer.delegate = self;
@@ -97,7 +100,10 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
     }
     
     [self.collectionView addGestureRecognizer:_longPressGestureRecognizer];
-    
+
+    if (_panGestureRecognizer) {
+        [self.collectionView removeGestureRecognizer:_panGestureRecognizer];
+    }
     _panGestureRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self
                                                                     action:@selector(handlePanGesture:)];
     _panGestureRecognizer.delegate = self;
@@ -111,7 +117,7 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
     self = [super init];
     if (self) {
         [self setDefaults];
-        [self addObserver:self forKeyPath:kLXCollectionViewKeyPath options:NSKeyValueObservingOptionNew context:nil];
+        [self addObserver:self forKeyPath:kLXCollectionViewKeyPath options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:nil];
     }
     return self;
 }
@@ -120,7 +126,7 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
     self = [super initWithCoder:aDecoder];
     if (self) {
         [self setDefaults];
-        [self addObserver:self forKeyPath:kLXCollectionViewKeyPath options:NSKeyValueObservingOptionNew context:nil];
+        [self addObserver:self forKeyPath:kLXCollectionViewKeyPath options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:nil];
     }
     return self;
 }
@@ -497,6 +503,9 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
         if (self.collectionView != nil) {
             [self setupCollectionView];
         } else {
+            UICollectionView *collectionView = change[NSKeyValueChangeOldKey];
+            [collectionView removeGestureRecognizer:_longPressGestureRecognizer];
+            [collectionView removeGestureRecognizer:_panGestureRecognizer];
             [self invalidatesScrollTimer];
         }
     }

--- a/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
+++ b/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
@@ -179,7 +179,7 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
     NSIndexPath *newIndexPath = [self.collectionView indexPathForItemAtPoint:self.currentView.center];
     NSIndexPath *previousIndexPath = self.selectedItemIndexPath;
     
-    if ((newIndexPath == nil) || [newIndexPath isEqual:previousIndexPath]) {
+    if (newIndexPath == nil || previousIndexPath == nil || [newIndexPath isEqual:previousIndexPath]) {
         return;
     }
     

--- a/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
+++ b/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
@@ -223,7 +223,7 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
         case LXScrollingDirectionUp: {
             distance = -distance;
             CGFloat minY = 0.0f - contentInset.top;
-            
+
             if ((contentOffset.y + distance) <= minY) {
                 distance = -contentOffset.y - contentInset.top;
             }
@@ -313,7 +313,11 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
              animations:^{
                  __strong typeof(self) strongSelf = weakSelf;
                  if (strongSelf) {
-                     strongSelf.currentView.transform = CGAffineTransformMakeScale(1.1f, 1.1f);
+                     if ([strongSelf.delegate respondsToSelector:@selector(collectionView:layout:adjustCurrentViewForDragAnimated:)]) {
+                         [strongSelf.delegate collectionView:strongSelf.collectionView layout:strongSelf adjustCurrentViewForDragAnimated:strongSelf.currentView];
+                     } else {
+                         strongSelf.currentView.transform = CGAffineTransformMakeScale(1.1f, 1.1f);
+                     }
                      highlightedImageView.alpha = 0.0f;
                      imageView.alpha = 1.0f;
                  }
@@ -353,6 +357,9 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
                  animations:^{
                      __strong typeof(self) strongSelf = weakSelf;
                      if (strongSelf) {
+                         if ([strongSelf.delegate respondsToSelector:@selector(collectionView:layout:adjustCurrentViewForDropAnimated:)]) {
+                             [strongSelf.delegate collectionView:strongSelf.collectionView layout:strongSelf adjustCurrentViewForDropAnimated:strongSelf.currentView];
+                         }
                          strongSelf.currentView.transform = CGAffineTransformMakeScale(1.0f, 1.0f);
                          strongSelf.currentView.center = layoutAttributes.center;
                      }
@@ -380,9 +387,14 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
     switch (gestureRecognizer.state) {
         case UIGestureRecognizerStateBegan:
         case UIGestureRecognizerStateChanged: {
-            self.panTranslationInCollectionView = [gestureRecognizer translationInView:self.collectionView];
-            CGPoint viewCenter = self.currentView.center = LXS_CGPointAdd(self.currentViewCenter, self.panTranslationInCollectionView);
-            
+            CGPoint directionalTranslation = [gestureRecognizer translationInView:self.collectionView];
+            if ([self.delegate respondsToSelector:@selector(collectionView:layout:adjustTranslation:forDragOfCurrentView:)]) {
+                directionalTranslation = [self.delegate collectionView:self.collectionView layout:self adjustTranslation:directionalTranslation forDragOfCurrentView:self.currentView];
+            }
+            self.panTranslationInCollectionView = directionalTranslation;
+            self.currentView.center = LXS_CGPointAdd(self.currentViewCenter, directionalTranslation);
+
+            CGPoint viewCenter = self.currentView.center;
             [self invalidateLayoutIfNecessary];
             
             switch (self.scrollDirection) {


### PR DESCRIPTION
...current dragging item.

This adds these delegate methods (all optional):

```
// Called as dragging starts from animation block to allow custom visual adjustments to the view.
- (void)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout adjustCurrentViewForDragAnimated:(UIView*)currentView;

// Called when the draggable view moves, giving the delegate a chance to control how it has moved.  Useful for restricting movement to a single direction or constraining it to a specific boundary.
- (CGPoint)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout adjustTranslation:(CGPoint)translation forDragOfCurrentView:(UIView*)currentView;

// Called as dragging ends from animation block to allow reversing the animations applied when dragging started.
- (void)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout adjustCurrentViewForDropAnimated:(UIView*)currentView;
```

Not implementing any of these methods provides the default behavior as it is prior to this change.
