### PR TITLE
Fixed bug of extraneous cells on rapid tapping.

### DIFF
--- a/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
+++ b/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
@@ -345,6 +345,8 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
                 
                 UICollectionViewLayoutAttributes *layoutAttributes = [self layoutAttributesForItemAtIndexPath:currentIndexPath];
                 
+                self.longPressGestureRecognizer.enabled = NO;
+                
                 __weak typeof(self) weakSelf = self;
                 [UIView
                  animateWithDuration:0.3
@@ -358,6 +360,9 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
                      }
                  }
                  completion:^(BOOL finished) {
+                     
+                     self.longPressGestureRecognizer.enabled = YES;
+                     
                      __strong typeof(self) strongSelf = weakSelf;
                      if (strongSelf) {
                          [strongSelf.currentView removeFromSuperview];


### PR DESCRIPTION
Setting the longPressGestureRecognizer’s minimumPressDuration property to 0, and then rapidly tapping on cells can cause extra cells to show up that are not able to be moved in any way. This fixes that issue by disabling the longPressGestureRecognizer until the animation that happens when the long press ends.
