### PR TITLE
Fixed intermittent crash when long press one cell & drag and tap/hold an...

### DIFF
--- a/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
+++ b/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
@@ -149,7 +149,7 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
     NSIndexPath *newIndexPath = [self.collectionView indexPathForItemAtPoint:self.currentView.center];
     NSIndexPath *previousIndexPath = self.selectedItemIndexPath;
     
-    if ((newIndexPath == nil) || [newIndexPath isEqual:previousIndexPath]) {
+    if ((newIndexPath == nil) || (previousIndexPath == nil) || [newIndexPath isEqual:previousIndexPath]) {
         return;
     }
     


### PR DESCRIPTION
...other cell.  When local variable 'previousIndexPath' is nil, the method -(void) invalidateLayoutIfNecessary will crash at line 171.  This fix prevents indexing into 'nil' at line 171.
