### PR TITLE
clean up gesture recognizers

### DIFF
--- a/LXRCVFL Example using Storyboard/LXRCVFL Example using Storyboard/LXCollectionViewController.m
+++ b/LXRCVFL Example using Storyboard/LXRCVFL Example using Storyboard/LXCollectionViewController.m
@@ -9,6 +9,7 @@
 #import "LXCollectionViewController.h"
 #import "PlayingCard.h"
 #import "PlayingCardCell.h"
+#import "LXReorderableCollectionViewFlowLayout.h"
 
 // LX_LIMITED_MOVEMENT:
 // 0 = Any card can move anywhere
@@ -20,6 +21,8 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+//    self.collectionView.collectionViewLayout = [LXReorderableCollectionViewFlowLayout new];
+//    self.collectionView.collectionViewLayout = [LXReorderableCollectionViewFlowLayout new];
     
     self.deck = [self constructsDeck];
 }

--- a/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
+++ b/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
@@ -126,8 +126,10 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
 }
 
 - (void)dealloc {
-    [self.collectionView removeGestureRecognizer:self.panGestureRecognizer];
-    [self.collectionView removeGestureRecognizer:self.longPressGestureRecognizer];
+
+    [self.panGestureRecognizer.view removeGestureRecognizer:self.panGestureRecognizer];
+    [self.longPressGestureRecognizer.view removeGestureRecognizer:self.longPressGestureRecognizer];
+    
     [self invalidatesScrollTimer];
     [self removeObserver:self forKeyPath:kLXCollectionViewKeyPath];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationWillResignActiveNotification object:nil];

--- a/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
+++ b/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
@@ -126,6 +126,8 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
 }
 
 - (void)dealloc {
+    [self.collectionView removeGestureRecognizer:self.panGestureRecognizer];
+    [self.collectionView removeGestureRecognizer:self.longPressGestureRecognizer];
     [self invalidatesScrollTimer];
     [self removeObserver:self forKeyPath:kLXCollectionViewKeyPath];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationWillResignActiveNotification object:nil];


### PR DESCRIPTION
I got a weird crash when I changed collectionViewFlowLayout dynamically.
Current version leaves gestures alive, so when the collectionView is tapped, gestureRecognizer will send message to zombie.