### PR TITLE
Bug/80 cleanup gestures

### DIFF
--- a/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
+++ b/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
@@ -511,7 +511,9 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context {
     if ([keyPath isEqualToString:kLXCollectionViewKeyPath]) {
         if (self.collectionView != nil) {
-            [self setupCollectionView];
+            if (self.longPressGestureRecognizer == nil) {
+                [self setupCollectionView];
+            }
         } else {
             [self invalidatesScrollTimer];
             [self tearDownCollectionView];


### PR DESCRIPTION
I am using animated transition to swap collection flow layouts, which sets collectionView few times.
Make sure we don't re-add gesture recognizers again.
