### PR TITLE
Long press bug fix

### DIFF
--- a/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
+++ b/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
@@ -298,14 +298,7 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
 - (void)handleLongPressGesture:(UILongPressGestureRecognizer *)gestureRecognizer {
     switch(gestureRecognizer.state) {
         case UIGestureRecognizerStateBegan: {
-            NSIndexPath *currentIndexPath = [self.collectionView indexPathForItemAtPoint:[gestureRecognizer locationInView:self.collectionView]];
-            
-            if ([self.dataSource respondsToSelector:@selector(collectionView:canMoveItemAtIndexPath:)] &&
-               ![self.dataSource collectionView:self.collectionView canMoveItemAtIndexPath:currentIndexPath]) {
-                return;
-            }
-            
-            self.selectedItemIndexPath = currentIndexPath;
+            self.selectedItemIndexPath = [self.collectionView indexPathForItemAtPoint:[gestureRecognizer locationInView:self.collectionView]];
             
             if ([self.delegate respondsToSelector:@selector(collectionView:layout:willBeginDraggingItemAtIndexPath:)]) {
                 [self.delegate collectionView:self.collectionView layout:self willBeginDraggingItemAtIndexPath:self.selectedItemIndexPath];
@@ -490,6 +483,13 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
     if ([self.panGestureRecognizer isEqual:gestureRecognizer]) {
         return (self.selectedItemIndexPath != nil);
+    } else {
+        NSIndexPath *currentIndexPath = [self.collectionView indexPathForItemAtPoint:[gestureRecognizer locationInView:self.collectionView]];
+        
+        if ([self.dataSource respondsToSelector:@selector(collectionView:canMoveItemAtIndexPath:)] &&
+            ![self.dataSource collectionView:self.collectionView canMoveItemAtIndexPath:currentIndexPath]) {
+            return NO;
+        }
     }
     return YES;
 }


### PR DESCRIPTION
Makes the long press gesture recongnizer begin only if the item can be moved, otherwise the gesture does nothing and cancels the others recognizers, resulting in the cell being deselected after a short time and not recognizing the tap gesture when the user lifts the finger.
