### PR TITLE
Bugfix: Incorrect begin indexpath

### DIFF
--- a/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
+++ b/LXReorderableCollectionViewFlowLayout/LXReorderableCollectionViewFlowLayout.m
@@ -331,6 +331,10 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
             
             self.currentViewCenter = self.currentView.center;
             
+            if ([self.delegate respondsToSelector:@selector(collectionView:layout:didBeginDraggingItemAtIndexPath:)]) {
+                  [self.delegate collectionView:strongSelf.collectionView layout:self didBeginDraggingItemAtIndexPath:self.selectedItemIndexPath];
+            }
+        
             __weak typeof(self) weakSelf = self;
             [UIView
              animateWithDuration:0.3
@@ -348,10 +352,6 @@ static NSString * const kLXCollectionViewKeyPath = @"collectionView";
                  __strong typeof(self) strongSelf = weakSelf;
                  if (strongSelf) {
                      [highlightedImageView removeFromSuperview];
-                     
-                     if ([strongSelf.delegate respondsToSelector:@selector(collectionView:layout:didBeginDraggingItemAtIndexPath:)]) {
-                         [strongSelf.delegate collectionView:strongSelf.collectionView layout:strongSelf didBeginDraggingItemAtIndexPath:strongSelf.selectedItemIndexPath];
-                     }
                  }
              }];
             


### PR DESCRIPTION
Dragging on long press gesture start (while the animation not ended) would cause beginning index path incorrect.